### PR TITLE
TOML Schemas

### DIFF
--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -1,0 +1,35 @@
+name: Publish Schemas
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  archival_template:
+    name: Publish archival_template.schema.json
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "TODO"
+      # TODO: check if this schema has changed
+      # If it has, publish a new PR to
+      # https://github.com/SchemaStore/schemastore/pulls
+  manifest:
+    name: Publish manifest.schema.json
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "TODO"
+      # TODO: check if this schema has changed
+      # If it has, publish a new PR to
+      # https://github.com/SchemaStore/schemastore/pulls
+  objects:
+    name: Publish objects.schema.json
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "TODO"
+      # TODO: check if this schema has changed
+      # If it has, publish a new PR to
+      # https://github.com/SchemaStore/schemastore/pulls

--- a/archival_template.schema.json
+++ b/archival_template.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://archival.dev/archival_template.schema.json",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of this template, to be shown to users and in the editor UI",
+      "type": "string"
+    },
+    "description": {
+      "description": "A (markdown-compatible) description of this template, to be shown to users and in the editor UI.",
+      "type": "string"
+    },
+    "assets": {
+      "description": "A list of assets that the template itself uses. These assets will not be copied when cloning the template, so this field also serves as an 'ignore' list. Items in this list follow the same conventions as a .gitignore line.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tags": {
+      "description": "A list of strings, which are arbitrary but can be used by the editor to generate context about this template.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "topics": {
+      "description": "A list of strings, which will be added as the topics of any github repos generated from this template.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context": {
+      "description": "This field defines human-readable context about this template that is used to help LLMs understand when it is appropriate to suggest this template, and may contain helpful meta-context about the schema provided by this template. For instance, this may contain text like 'the site.file field is displayed as the primary download for the site, and should be a zip file'.",
+      "type": "string"
+    },
+    "tlds": {
+      "description": "This field is a list of strings, which should all be valid tlds (including the leading dot) that might be a good match for this template. For instance, an app template might list '.app'.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "required": ["name", "description"]
+  }
+}

--- a/manifest.schema.json
+++ b/manifest.schema.json
@@ -1,6 +1,8 @@
 {
-  "$id": "jesseditson/archival/v0.10.5/app.schema.json",
+  "$id": "jesseditson/archival/v0.10.4/manifest.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "type": "object",
   "properties": {
     "upload_prefix": {
       "description": "this string is appended to all upload paths, used for differentiating sites using the same uploads_url",
@@ -66,8 +68,11 @@
     },
     "editor_types": {
       "type": "object",
+      "description": "a dictionary of custom-defined editor types",
+      "additionalProperties": false,
       "properties": {
         "type": {
+          "description": "the type that this custom type is backed with",
           "enum": [
             "string",
             "number",
@@ -83,6 +88,7 @@
           "type": "string"
         },
         "editor_url": {
+          "description": "a URL to load a custom editor from. If unspecified, will use the underlying type's editor",
           "type": "string"
         },
         "validate": {
@@ -96,6 +102,7 @@
               },
               {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "path": {
                     "type": "string",
@@ -112,6 +119,5 @@
         }
       }
     }
-  },
-  "type": "object"
+  }
 }

--- a/manifest.schema.json
+++ b/manifest.schema.json
@@ -1,0 +1,117 @@
+{
+  "$id": "jesseditson/archival/v0.10.5/app.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "upload_prefix": {
+      "description": "this string is appended to all upload paths, used for differentiating sites using the same uploads_url",
+      "type": "string"
+    },
+    "uploads_url": {
+      "description": "the host url of the CDN used for uploads",
+      "type": "string"
+    },
+    "archival_version": {
+      "description": "an optional version string to indicate the minimum version of archival this site is compatible with",
+      "type": "string"
+    },
+    "prebuild": {
+      "description": "a list of shell commands to run before building this site",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "site_url": {
+      "description": "a url that will be available to this site's liquid files as site_url, which can also be used by the archival editor",
+      "type": "string"
+    },
+    "site_name": {
+      "description": "a name for this site, used by the archival editor and other machine readers of this manifest",
+      "type": "string"
+    },
+    "object_definition_file": {
+      "description": "the file that archival uses to read the objects schema for this site",
+      "type": "string",
+      "default": "objects.toml"
+    },
+    "pages_dir": {
+      "description": "the folder that archival looks for page liquid files in",
+      "type": "string",
+      "default": "pages"
+    },
+    "objects_dir": {
+      "description": "the folder that archival looks for object toml files in",
+      "type": "string",
+      "default": "objects.toml"
+    },
+    "schemas_dir": {
+      "description": "the folder that the archival schemas command generates schemas into",
+      "type": "string",
+      "default": "schemas"
+    },
+    "build_dir": {
+      "description": "the folder that archival builds your site into",
+      "type": "string",
+      "default": "dist"
+    },
+    "static_dir": {
+      "description": "the static dir that is copied directly to your build dir",
+      "type": "string",
+      "default": "public"
+    },
+    "layout_dir": {
+      "description": "the folder that archival reads layouts from",
+      "type": "string",
+      "default": "layout"
+    },
+    "editor_types": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "date",
+            "markdown",
+            "image",
+            "video",
+            "audio",
+            "upload",
+            "meta"
+          ],
+          "type": "string"
+        },
+        "editor_url": {
+          "type": "string"
+        },
+        "validate": {
+          "type": "array",
+          "description": "a list of validations to run on fields of this type",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "a regular expression to run on this field's string representation"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "a path inside a meta field to validate"
+                  },
+                  "validate": {
+                    "type": "string",
+                    "description": "a regular expression to run on this field at the specified path"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/objects.schema.json
+++ b/objects.schema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "jesseditson/archival/v0.10.4/objects.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "id": "object_def",
+  "patternProperties": {
+    "^[a-zA-Z0-9_-]+$": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "the archival type that this field will use. NOTE: this schema does not yet support custom types.",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "date",
+            "markdown",
+            "image",
+            "video",
+            "audio",
+            "upload",
+            "meta"
+          ]
+        },
+        {
+          "$ref": "#",
+          "description": "a child object definition"
+        }
+      ]
+    }
+  },
+  "propertyNames": {
+    "not": {
+      "anyOf": [
+        { "const": "template" },
+        { "const": "order" },
+        { "const": "objects" },
+        { "const": "object_name" },
+        { "const": "page" },
+        { "const": "page_name" },
+        { "const": "site_url" }
+      ]
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
In support of #35, archival already supports exporting schemas for individual object definitions.

This PR contains both definitions and publishing jobs for the root-level schemas `manifest.toml` and `objects.toml`, along with the schema used in templates in `archival_template.toml`.